### PR TITLE
[fix] Fixed push tags action doesn't run when publishing draft release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,8 @@
 name: publish
 
 on:
-  push:
-    branches:
-      - "!*"
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
Reference: https://github.com/release-drafter/release-drafter/issues/876